### PR TITLE
Bugfix/ecbuild35 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ endif()
 
 
 # Fortran module output directory for build and install interfaces
-set(MODULE_DIR ${PROJECT_NAME}/module/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set(MODULE_DIR ${PROJECT_NAME}/module)
 set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
 target_include_directories(${PROJECT_NAME} INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,89 +7,31 @@
 # FMS
 ################################################################################
 
-cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
-
+cmake_minimum_required( VERSION 3.12 )
 project( fms VERSION 2020.4.0 LANGUAGES C Fortran )
 
-set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH} )
-
-set( CMAKE_DIRECTORY_LABELS "fms" )
-
-set( ECBUILD_DEFAULT_BUILD_TYPE Release )
-set( ENABLE_OS_TESTS           OFF CACHE BOOL "Disable OS tests" FORCE )
-set( ENABLE_LARGE_FILE_SUPPORT OFF CACHE BOOL "Disable testing of large file support" FORCE )
-set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
-
+## Ecbuild integration
+find_package( ecbuild 3.3.2 REQUIRED )
 include( ecbuild_system NO_POLICY_SCOPE )
-
-ecbuild_requires_macro_version( 2.7 )
-
-################################################################################
-# Project
-################################################################################
-
 ecbuild_declare_project()
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 
-ecbuild_enable_fortran( REQUIRED )
-
-set( FMS_LINKER_LANGUAGE Fortran )
+include( fms_compiler_flags )
 
 ################################################################################
 # Dependencies
 ################################################################################
 
-# MPI
-find_package( MPI REQUIRED COMPONENTS C CXX Fortran )
-
-# OpenMP
-if( HAVE_OMP )
-  ecbuild_enable_omp()
-else()
-  ecbuild_enable_ompstubs()
-endif()
-
-# jedi-cmake
 find_package( jedicmake QUIET)
-
-# NetCDF
+find_package( MPI REQUIRED COMPONENTS C Fortran )
+find_package( OpenMP COMPONENTS C Fortran )
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
-
-################################################################################
-# Definitions
-################################################################################
-
-################################################################################
-# Export package info
-################################################################################
-
-set( FMS_INCLUDE_DIRS ${CMAKE_Fortran_MODULE_DIRECTORY}
-                      ${CMAKE_CURRENT_SOURCE_DIR}/include
-                      ${CMAKE_CURRENT_SOURCE_DIR}/fms2_io/include
-                      ${CMAKE_CURRENT_SOURCE_DIR}/mpp/include
-                      ${CMAKE_CURRENT_SOURCE_DIR}/fms)
-set( FMS_LIBRARIES fms )
-
-get_directory_property( FMS_DEFINITIONS COMPILE_DEFINITIONS )
-
-list( APPEND FMS_TPLS NetCDF )
-
-foreach( _tpl ${FMS_TPLS} )
-  string( TOUPPER ${_tpl} TPL )
-  list( APPEND FMS_EXTRA_DEFINITIONS   ${${TPL}_DEFINITIONS}  ${${TPL}_TPL_DEFINITIONS}  )
-  list( APPEND FMS_EXTRA_INCLUDE_DIRS  ${${TPL}_INCLUDE_DIRS} ${${TPL}_TPL_INCLUDE_DIRS} )
-  list( APPEND FMS_EXTRA_LIBRARIES     ${${TPL}_LIBRARIES}    ${${TPL}_TPL_LIBRARIES}    )
-endforeach()
 
 ################################################################################
 # Sources
 ################################################################################
 
-# FMS compiler flags are set here (e.g. -Duse_libMPI, etc.)
-include( fms_compiler_flags )
-
-include_directories( ${FMS_INCLUDE_DIRS} ${FMS_EXTRA_INCLUDE_DIRS} )
-
-################################################################################
 list( APPEND fms_hdr_files
 include/file_version.h
 include/fms_platform.h
@@ -328,20 +270,25 @@ list( APPEND fms_src_files
 ################################################################################
 ecbuild_add_library( TARGET   fms
                      SOURCES  ${fms_hdr_files} ${fms_src_files}
-                     PUBLIC_LIBS     ${NetCDF_LIBRARIES} MPI::MPI_Fortran
                      INSTALL_HEADERS_LIST ${fms_hdr_files}
                      LINKER_LANGUAGE ${FMS_LINKER_LANGUAGE}
                     )
 
+# Link dependencies
+target_link_libraries( fms PUBLIC NetCDF::NetCDF_Fortran )
+target_link_libraries( fms PUBLIC MPI::MPI_Fortran )
+target_link_libraries( fms PUBLIC OpenMP::OpenMP_C OpenMP::OpenMP_Fortran )
+
 ################################################################################
 
+# Enable support for GFortran >= 10.x
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
     target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-fallow-invalid-boz>
                                                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
 endif()
 
 if(UNIX AND NOT APPLE)
-    #glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
+    #FIX for glibc>=2.30 which includes gettid in unistd.h if _GNU_SOURCE is set
     include(CheckSymbolExists)
     set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
     check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
@@ -351,21 +298,20 @@ if(UNIX AND NOT APPLE)
     endif()
 endif()
 
-if(ECBUILD_INSTALL_FORTRAN_MODULES)
-   install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
-endif()
+
+# Fortran module output directory for build and install interfaces
+set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
+target_include_directories(${PROJECT_NAME} INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                            $<INSTALL_INTERFACE:${MODULE_DIR}>)
 
 target_include_directories( fms INTERFACE
                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include
                     $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
-################################################################################
-# Finalise configuration
-################################################################################
-
-# prepares a tar.gz of the sources and/or binaries
+# Export package config
 ecbuild_install_project( NAME fms )
-
-# print the summary of the configuration
 ecbuild_print_summary()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ list( APPEND fms_src_files
 ################################################################################
 ecbuild_add_library( TARGET   fms
                      SOURCES  ${fms_hdr_files} ${fms_src_files}
-                     PUBLIC_LIBS     ${NetCDF_LIBRARIES}
+                     PUBLIC_LIBS     ${NetCDF_LIBRARIES} MPI::MPI_Fortran
                      INSTALL_HEADERS_LIST ${fms_hdr_files}
                      LINKER_LANGUAGE ${FMS_LINKER_LANGUAGE}
                     )
@@ -340,14 +340,14 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERS
                                                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
 endif()
 
-# glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
-#include(CheckSymbolExists)
-#set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
-#check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
-#unset(CMAKE_REQUIRED_DEFINITIONS)
-#if(HAVE_GETTID)
-#    target_compile_definitions(fms PRIVATE HAVE_GETTID)
-#endif()
+#glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
+check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
+unset(CMAKE_REQUIRED_DEFINITIONS)
+if(HAVE_GETTID)
+   target_compile_definitions(fms PRIVATE HAVE_GETTID)
+endif()
 
 if(ECBUILD_INSTALL_FORTRAN_MODULES)
    install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,9 +303,9 @@ endif()
 
 
 # Fortran module output directory for build and install interfaces
-set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set(MODULE_DIR ${PROJECT_NAME}/module/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
 set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
-install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
 target_include_directories(${PROJECT_NAME} INTERFACE
                             $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
                             $<INSTALL_INTERFACE:${MODULE_DIR}>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,13 +340,15 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERS
                                                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
 endif()
 
-#glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
-include(CheckSymbolExists)
-set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
-check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
-unset(CMAKE_REQUIRED_DEFINITIONS)
-if(HAVE_GETTID)
-   target_compile_definitions(fms PRIVATE HAVE_GETTID)
+if(UNIX AND NOT APPLE)
+    #glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
+    include(CheckSymbolExists)
+    set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
+    check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
+    unset(CMAKE_REQUIRED_DEFINITIONS)
+    if(HAVE_GETTID)
+        target_compile_definitions(fms PRIVATE HAVE_GETTID)
+    endif()
 endif()
 
 if(ECBUILD_INSTALL_FORTRAN_MODULES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,18 +281,21 @@ target_link_libraries( fms PUBLIC OpenMP::OpenMP_C OpenMP::OpenMP_Fortran )
 
 ################################################################################
 
-# Enable support for GFortran >= 10.x
+# Disable compiler checks for GFortran >= 10.x
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
     target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-fallow-invalid-boz>
                                                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
 endif()
 
 if(UNIX AND NOT APPLE)
-    #FIX for glibc>=2.30 which includes gettid in unistd.h if _GNU_SOURCE is set
+    #FIX for linking error with glibc>=2.30 which includes gettid in unistd.h if macro _GNU_SOURCE is set
     include(CheckSymbolExists)
+    include(CMakePushCheckState)
+    cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
     check_symbol_exists("gettid" "unistd.h" HAVE_GETTID)
     unset(CMAKE_REQUIRED_DEFINITIONS)
+    cmake_pop_check_state() # Restore any modified state
     if(HAVE_GETTID)
         target_compile_definitions(fms PRIVATE HAVE_GETTID)
     endif()
@@ -307,9 +310,15 @@ target_include_directories(${PROJECT_NAME} INTERFACE
                             $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
                             $<INSTALL_INTERFACE:${MODULE_DIR}>)
 
-target_include_directories( fms INTERFACE
-                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include
-                    $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+# Private .inc include locations
+target_include_directories( fms PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mpp/include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/fms2_io/include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/fms)
+
+# Installed .h include locations (fms_hdr_files)
+target_include_directories( fms PUBLIC
+                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 # Export package config

--- a/cmake/fms_compiler_flags.cmake
+++ b/cmake/fms_compiler_flags.cmake
@@ -6,7 +6,7 @@
 
 # Standard FMS compiler definitions
 # ---------------------------------
-add_definitions( -Duse_libMPI -DSPMD -Duse_netCDF -Duse_LARGEFILE -DGFS_PHYS )
+add_definitions( -Duse_libMPI -DSPMD -Duse_netCDF -Duse_LARGEFILE -DGFS_PHYS -DINTERNAL_FILE_NML )
 
 # Special cases
 # -------------

--- a/fms-import.cmake.in
+++ b/fms-import.cmake.in
@@ -1,0 +1,26 @@
+# fms-import.cmake
+# find_dependency calls for fms target dependencies
+
+include(CMakeFindDependencyMacro)
+
+if(NOT NetCDF_Fortran_FOUND)
+    find_package( NetCDF REQUIRED COMPONENTS Fortran )
+endif()
+
+if(NOT MPI_Fortran_FOUND)
+    find_package( MPI REQUIRED COMPONENTS Fortran )
+endif()
+
+if(NOT OpenMP_Fortran_FOUND OR NOT OpenMP_C_FOUND )
+    find_package( OpenMP REQUIRED COMPONENTS C Fortran )
+endif()
+
+#Export Fortran compiler version for checking module compatibility
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@)
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION @CMAKE_Fortran_COMPILER_VERSION@)
+if(NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILER_ID
+   OR NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION VERSION_EQUAL CMAKE_Fortran_COMPILER_VERSION)
+    message(SEND_ERROR "Package @PROJECT_NAME@ provides Fortran modules built with "
+            "${@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID}-${@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION} "
+            "but this build for ${PROJECT_NAME} uses incompatible compiler ${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}")
+endif()


### PR DESCRIPTION
**Description**
This is a compatibility update to cleanup ecbuild code for the transition to ecbuild3.5.

Several small fixes and removal and/or replacement of older code which is no longer functional
* Correct CMake minimum version
* Update the ecbuild project config code to remove obsolete options and commands.  This code now matches the common ecbuild initialization code in e.g., oops, ioda, saber, etc. which are backwards and forwards comparable with relevant ecbuild versions. 
* Link to only the required language-specific targets for NetCDF, MPI, and OpenMP to prevent creating false or unnecessary dependencies.
* Include a `fms-imports.cmake.in` to propagate these target dependencies.  This replaces the old ecbuild `*_TPLS` variables and associated code which is no longer functioning.
* Re-enable the fix for linking against `glibc>=2.30`, where presence of the `gettid` symbol needs to be checked for at compile time.
  * Fix for potential issue: use `cmake_push_check_state()` to preserve the state of the `CMAKE_REQUIRED_DEFINITIONS` variable during this compiler check.
  * Disabled this check for `APPLE` systems.

**How Has This Been Tested?**

Builds have been tested with GNU and Intel stacks in the current JEDI-Stack environment with both the old and new ecbuild versions.  Will also test on the following platforms:
- [x] Orion
- [x] S4
- [x] Discover
- [x] OSX

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

