### PR TITLE
[bugfix] fix module install location / make SOCA TravisCI happy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAK
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
 target_include_directories(${PROJECT_NAME} INTERFACE
                             $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
-                            $<INSTALL_INTERFACE:${MODULE_DIR}>)
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR}>)
 
 # Private .inc include locations
 target_include_directories( fms PRIVATE


### PR DESCRIPTION
**Description**
The location of fortran module files when doing 'make install` and the location when trying to use those files was not consistent.
This fixes that. Tested with https://github.com/JCSDA-internal/soca/pull/574 (TravisCI tests find FMS now, but it is failing latter on due to other unrelated issues, see https://travis-ci.com/github/JCSDA-internal/soca/builds/226130015)